### PR TITLE
Support for Keep Construct Phases

### DIFF
--- a/src/statistics/Statistics.java
+++ b/src/statistics/Statistics.java
@@ -463,7 +463,8 @@ public class Statistics {
 
 		List<Point> fight_intervals = new ArrayList<Point>();
 		List<CombatItem> combatList = combatData.getCombatList();
-		int timeStart = bossData.getFirstAware() - combatList.get(0).getTime();
+		int combatStart = combatList.get(0).getTime();
+		int timeStart = bossData.getFirstAware() - combatStart;
 
 		int i_count;
 		int t_invuln;
@@ -486,7 +487,42 @@ public class Statistics {
 		} else if (bossData.getName().equals("Samarog")) {
 			i_count = 2;
 			t_invuln = 20000;
-		} else {
+		} else if (bossData.getName().equals("Keep Construct")) {
+			int t_curr = 0;
+			int t_prev = timeStart;
+			// Flag to show first phase before burn phases
+			boolean first_phase_flag = true;
+			// Flag to prevent multiple invuln phases causing more intervals
+			boolean same_phase_flag = false;
+			for (CombatItem c : combatList) {
+				t_curr = c.getTime();
+				if (c.getSrcAgent() == bossData.getAgent()) {
+					// Start of invulnerability (757 is invulnerability skill id)
+					if (c.getSkillID() == 757 && c.getDstAgent() == bossData.getAgent()) {
+						if (first_phase_flag) {
+							fight_intervals.add(new Point(t_prev, t_curr - combatStart));
+							first_phase_flag = false;
+						}
+						// End of invulnerability (DstAgent is not set)
+					} else if (c.getSkillID() == 757) {
+						if (!same_phase_flag) {
+							t_prev = t_curr - combatStart;
+						}
+						same_phase_flag = true;
+						// Start of red/white orb phase (35025 is Xera's Boon skill id)
+					} else if (c.getSkillID() == 35025 && c.getDstAgent() == bossData.getAgent()) {
+						fight_intervals.add(new Point(t_prev, t_curr - combatStart));
+						same_phase_flag = false;
+						// End of red/white orb phase
+					} else if (c.getSkillID() == 35025) {
+						t_prev = t_curr - combatStart;
+					}
+				}
+			}
+			// Add last burn phase
+			fight_intervals.add(new Point(t_prev, bossData.getLastAware() - combatStart));
+			return fight_intervals;
+		}else {
 			fight_intervals.add(new Point(timeStart, bossData.getLastAware() - bossData.getFirstAware()));
 			return fight_intervals;
 		}

--- a/src/statistics/Statistics.java
+++ b/src/statistics/Statistics.java
@@ -30,6 +30,8 @@ import enums.StateChange;
 import player.BoonLog;
 import player.DamageLog;
 import player.Player;
+import utility.FinalDpsHolder;
+import utility.PhaseDpsHolder;
 import utility.TableBuilder;
 import utility.Utility;
 
@@ -56,13 +58,15 @@ public class Statistics {
 		for (AgentItem playerAgent : playerAgentList) {
 			this.playerList.add(new Player(playerAgent));
 		}
+		// Sort players by subgroup - also added in to each function in case different sorts are used in the future
+		sortPlayerList();
 	}
 
 	// Final DPS
 	public String getFinalDPS() {
 
-		List<String> dps = new ArrayList<String>();
-		List<String> dmg = new ArrayList<String>();
+	    // Holder used to allow sorting by dps
+        List<FinalDpsHolder> holder = new ArrayList<FinalDpsHolder>();
 
 		int total_damage = 0;
 		double total_dps = 0.0;
@@ -74,13 +78,14 @@ public class Statistics {
 			for (DamageLog log : damage_logs) {
 				player_damage = player_damage + log.getDamage();
 			}
-
-			dps.add(String.format("%.2f", (player_damage / fight_duration)));
-			dmg.add(String.valueOf((int) player_damage));
+            holder.add(new FinalDpsHolder(p, String.format("%.2f", (player_damage / fight_duration)), player_damage));
 
 			total_dps = total_dps + (player_damage / fight_duration);
 			total_damage = (int) (total_damage + player_damage);
 		}
+
+		// Sort players by damage (and therefore dps)
+        holder.sort((a,b) -> (int) (b.getDamage() - a.getDamage()));
 
 		// Table
 		TableBuilder table = new TableBuilder();
@@ -90,9 +95,10 @@ public class Statistics {
 		table.addRow("Name", "Profession", "DPS", "Damage");
 
 		// Body
-		for (int i = 0; i < playerList.size(); i++) {
-			Player p = playerList.get(i);
-			table.addRow(p.getCharacter(), p.getProf(), dps.get(i), dmg.get(i));
+		for (int i = 0; i < holder.size(); i++) {
+		    FinalDpsHolder h = holder.get(i);
+            Player p = h.getPlayer();
+            table.addRow(p.getCharacter(), p.getProf(), h.getDps(), String.valueOf((int) h.getDamage()));
 		}
 
 		// Footer
@@ -106,7 +112,7 @@ public class Statistics {
 	public String getPhaseDPS() {
 
 		List<Point> fight_intervals = getFightIntervals();
-		List<String[]> all_phase_dps = new ArrayList<String[]>();
+        List<PhaseDpsHolder> holder = new ArrayList<PhaseDpsHolder>();
 
 		for (int i = 0; i < playerList.size(); i++) {
 
@@ -132,8 +138,11 @@ public class Statistics {
 			}
 
 			phase_dps[fight_intervals.size()] = String.format("%.2f", average_dps);
-			all_phase_dps.add(phase_dps);
+            holder.add(new PhaseDpsHolder(p, phase_dps, average_dps));
 		}
+
+		// Sort players by average dps
+        holder.sort((a,b) -> (int) (b.getAverage_dps() - a.getAverage_dps()));
 
 		// Table
 		TableBuilder table = new TableBuilder();
@@ -150,10 +159,11 @@ public class Statistics {
 		table.addRow(header);
 
 		// Body
-		for (int i = 0; i < playerList.size(); i++) {
-			Player p = playerList.get(i);
+		for (int i = 0; i <holder.size(); i++) {
+			PhaseDpsHolder h = holder.get(i);
+			Player p = h.getPlayer();
 			table.addRow(
-					Utility.concatStringArray(new String[] { p.getCharacter(), p.getProf() }, all_phase_dps.get(i)));
+                    Utility.concatStringArray(new String[] { p.getCharacter(), p.getProf() }, h.getAll_phase_dps()));
 		}
 
 		// Footer
@@ -286,6 +296,9 @@ public class Statistics {
 		table.addRow("Account", "Character", "Group", "Profession", "CRIT", "SCHL", "MOVE", "FLNK", "TGHN", "HEAL",
 				"COND", "DOGE", "RESS", "DOWN", "DIED");
 
+		// Sort players by subgroup
+		sortPlayerList();
+
 		// Body
 		for (Player p : playerList) {
 
@@ -351,6 +364,9 @@ public class Statistics {
 		BoonFactory boonFactory = new BoonFactory();
 		List<String[]> all_rates = new ArrayList<String[]>();
 
+		// Sort players by subgroup
+		sortPlayerList();
+
 		for (int i = 0; i < playerList.size(); i++) {
 			Player p = playerList.get(i);
 			Map<String, List<BoonLog>> boon_logs = p.getBoonMap(bossData, skillData, combatData.getCombatList());
@@ -396,6 +412,9 @@ public class Statistics {
 		BoonFactory boonFactory = new BoonFactory();
 		List<String[][]> all_rates = new ArrayList<String[][]>();
 		List<Point> fight_intervals = getFightIntervals();
+
+		// Sort players by subgroup
+		sortPlayerList();
 
 		for (int i = 0; i < playerList.size(); i++) {
 
@@ -676,6 +695,11 @@ public class Statistics {
 			phase_stacks[i] = String.format("%.2f", average_stacks / phase_boon_stacks.size());
 		}
 		return phase_stacks;
+	}
+
+	// resorts the player list by subgroup - checks for "N/A" for logs before subgroups were added
+	private void sortPlayerList() {
+		playerList.sort((a,b) -> Integer.parseInt(a.getGroup()!="N/A"?a.getGroup():"0") - Integer.parseInt(b.getGroup()!="N/A"?b.getGroup():"0"));
 	}
 
 }

--- a/src/utility/FinalDpsHolder.java
+++ b/src/utility/FinalDpsHolder.java
@@ -1,0 +1,25 @@
+package utility;
+
+import player.Player;
+
+public class FinalDpsHolder {
+
+    // Fields
+    private Player player;
+    private String dps;
+    private double damage;
+
+    // Constructor
+    public FinalDpsHolder(Player p, String dp, double dmg) {
+        this.player = p;
+        this.dps = dp;
+        this.damage = dmg;
+    }
+
+    // Getters
+    public Player getPlayer() { return player; }
+
+    public String getDps() { return dps; }
+
+    public double getDamage() { return damage; }
+}

--- a/src/utility/PhaseDpsHolder.java
+++ b/src/utility/PhaseDpsHolder.java
@@ -1,0 +1,25 @@
+package utility;
+
+
+import player.Player;
+
+public class PhaseDpsHolder {
+    // Fields
+    private Player player;
+    private String[] all_phase_dps;
+    private double average_dps;
+
+    // Constructor
+    public PhaseDpsHolder(Player p, String[] all_dps, double avg) {
+        this.player = p;
+        this.all_phase_dps = all_dps;
+        this.average_dps = avg;
+    }
+
+    // Getters
+    public Player getPlayer() { return player; }
+
+    public String[] getAll_phase_dps() { return all_phase_dps; }
+
+    public double getAverage_dps() { return average_dps; }
+}


### PR DESCRIPTION
Add support for keep construct intervals. Focuses on burn phases by splitting fight into:
- Phase 1 - time to first invulnerability (skill id 757)
- Phase 2 66% - from end of first invulnerability to Xera's Boon (skill id 35025) application indicating 66% (start of red/white orbs)
- Phase 3 33% - from end of first invulnerability this phase to Xera's Boon (skill id 35025) application indicating 33% (start of red/white orbs)
- Phase 4 0% - from end of first invulnerability this phase to boss death

Therefore ignores some phases of dps inbetween (Xera's Boon removal to first invulnerability that phase). Copes with multiple invulnerabilities in each phase (not able to burn in one go).